### PR TITLE
Ensure that the document is mutable.

### DIFF
--- a/firebase-document.html
+++ b/firebase-document.html
@@ -56,8 +56,7 @@ document.
        */
       data: {
         type: Object,
-        notify: true,
-        readOnly: true
+        notify: true
       }
     },
 
@@ -81,7 +80,7 @@ document.
 
     _onFirebaseValue: function(event) {
       this._applyRemoteDataChange(function() {
-        this._setData(event.detail.val());
+        this.set('data', event.detail.val());
       });
     },
 

--- a/test/firebase-document.html
+++ b/test/firebase-document.html
@@ -31,6 +31,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </firebase-document>
     </template>
   </test-fixture>
+  <test-fixture id="UpdateableDocument">
+    <template>
+      <firebase-document
+        location="https://fb-element-demo.firebaseio.com/test/updateable_document"
+        log>
+      </firebase-document>
+    </template>
+  </test-fixture>
   <test-fixture id="MalleableDocument">
     <template>
       <firebase-document
@@ -66,6 +74,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }).catch(function() {
             done(e);
           });
+        });
+      });
+
+      suite('document updating', function() {
+        setup(function(done) {
+          firebase = fixture('UpdateableDocument');
+          waitForEvent(firebase, 'firebase-value').then(function() {
+            done();
+          });
+        });
+
+        test('setting data property updates the document', function(done) {
+          var data = {};
+          var newValue = Math.random().toString().split('.').pop();
+
+          data[newValue] = newValue;
+
+          waitForEvent(firebase, 'firebase-value').then(function() {
+            expect(firebase.data[newValue]).to.be.eql(newValue);
+            done();
+          }).catch(function(e) {
+            done(e);
+          }).then(function() {
+            firebase.set('data.' + newValue, null);
+          });
+
+          firebase.set('data', data);
         });
       });
 


### PR DESCRIPTION
The `data` attribute on `firebase-document` was accidentally `readOnly`. The intended implementation is for the `data` attribute to "update" the remote Firebase document when it is set wholesale.

Fixes #24 

/cc @notwaldorf @morethanreal