### PR TITLE
Various bug-fixes related to looking up and syncing data.

### DIFF
--- a/firebase-collection.html
+++ b/firebase-collection.html
@@ -54,421 +54,460 @@ manipulation of the collection without direct knowledge of Firebase key values.
 -->
 
 <script>
-  Polymer({
-    is: 'firebase-collection',
+  (function() {
+    'use strict'
 
-    behaviors: [
-      Polymer.FirebaseQueryBehavior
-    ],
+    var FirebaseCollection = Polymer({
+      is: 'firebase-collection',
 
-    properties: {
-      /**
-       * A pointer to the current Firebase Query instance being used to
-       * populate `data`.
-       */
-      query: {
-        type: Object,
-        notify: true,
-        computed: '_computeQuery(location, limitToFirst, limitToLast, _orderByMethodName, _startAt, _endAt, _equalTo)',
-        observer: '_queryChanged'
-      },
+      behaviors: [
+        Polymer.FirebaseQueryBehavior
+      ],
 
-      /**
-       * An ordered array of data items produced by the current Firebase Query
-       * instance.
-       */
-      data: {
-        type: Array,
-        readOnly: true,
-        notify: true,
-        value: function() {
-          return [];
+      properties: {
+        /**
+         * A pointer to the current Firebase Query instance being used to
+         * populate `data`.
+         */
+        query: {
+          type: Object,
+          notify: true,
+          computed: '_computeQuery(location, limitToFirst, limitToLast, _orderByMethodName, _startAt, _endAt, _equalTo)',
+          observer: '_queryChanged'
+        },
+
+        /**
+         * An ordered array of data items produced by the current Firebase Query
+         * instance.
+         */
+        data: {
+          type: Array,
+          readOnly: true,
+          notify: true,
+          value: function() {
+            return [];
+          }
+        },
+
+        /**
+         * Specify a child key to order the set of records reflected on the
+         * client.
+         */
+        orderByChild: {
+          type: String,
+          value: null,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Specify to order by key the set of records reflected on the client.
+         */
+        orderByKey: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Specify to order by value the set of records reflected on the client.
+         */
+        orderByValue: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Specify to order by priority the set of records reflected on the
+         * client.
+         */
+        orderByPriority: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Specify a maximum number of records reflected on the client limited to
+         * the first certain number of children.
+         */
+        limitToFirst: {
+          type: Number,
+          value: null,
+          reflectToAttribute: true,
+        },
+
+        /**
+         * Specify a maximum number of records reflected on the client limited to
+         * the last certain number of children.
+         */
+        limitToLast: {
+          type: Number,
+          value: null,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Specify a start record for the set of records reflected in the
+         * collection.
+         */
+        startAt: {
+          type: String,
+          value: null,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Specify an end record for the set of records reflected in the
+         * collection.
+         */
+        endAt: {
+          type: String,
+          value: null,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Specify to create a query which includes children which match the
+         * specified value. The argument type depends on which orderBy*() function
+         * was used in this query. Specify a value that matches the orderBy*()
+         * type.
+         */
+        equalTo: {
+          type: String,
+          value: null,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Specify to override the type used when deserializing the value of
+         * `start-at`, `end-at` and `equal-to` attributes. By default, these
+         * values are always deserialized as `String`, but sometimes it is
+         * preferrable to deserialize these values as e.g., `Number`.
+         *
+         * Accepted values for this attribute, and their corresponding
+         * deserialization types, are as follows:
+         *
+         *  - `string` => `String` (default)
+         *  - `number` => `Number`
+         *  - `boolean` => `Boolean`
+         */
+        orderValueType: {
+          type: String,
+          value: 'string',
+          reflectToAttribute: true
+        },
+
+        _valueMap: {
+          type: Object,
+          value: function() {
+            return {};
+          }
+        },
+
+        _orderByMethodName: {
+          computed: '_computeOrderByMethodName(orderByChild, orderByKey, orderByValue, orderByPriority)'
+        },
+
+        _orderByTypeCast: {
+          computed: '_computeOrderByTypeCast(orderByChild, orderByKey, orderByValue, orderByPriority, orderValueType)'
+        },
+
+        _startAt: {
+          computed: '_computeStartAt(startAt, _orderByTypeCast)'
+        },
+
+        _endAt: {
+          computed: '_computeEndAt(endAt, _orderByTypeCast)'
+        },
+
+        _equalTo: {
+          computed: '_computeEqualTo(equalTo, _orderByTypeCast)'
         }
       },
 
-      /**
-       * Specify a child key to order the set of records reflected on the
-       * client.
-       */
-      orderByChild: {
-        type: String,
-        value: null,
-        reflectToAttribute: true
+      listeners: {
+        'firebase-child-added': '_onFirebaseChildAdded',
+        'firebase-child-removed': '_onFirebaseChildRemoved',
+        'firebase-child-changed': '_onFirebaseChildChanged',
+        'firebase-child-moved': '_onFirebaseChildChanged',
       },
 
       /**
-       * Specify to order by key the set of records reflected on the client.
+       * Add an item to the document referenced at `location`. A key associated
+       * with the item will be created by Firebase, and can be accessed via the
+       * Firebase Query instance returned by this method.
+       *
+       * @param {Object} data A value to add to the document.
+       * @return {Object} A Firebase Query instance referring to the added item.
        */
-      orderByKey: {
-        type: Boolean,
-        value: false,
-        reflectToAttribute: true
+      add: function(data) {
+        var query;
+
+        this._log('Adding new item to collection with value:', data);
+
+        query = this.query.ref().push();
+        query.set(data);
+
+        return query;
       },
 
       /**
-       * Specify to order by value the set of records reflected on the client.
+       * Remove an item from the document referenced at `location`. The item
+       * is assumed to be an identical reference to an item already in the
+       * `data` Array.
+       *
+       * @param {Object} data An identical reference to an item in `this.data`.
        */
-      orderByValue: {
-        type: Boolean,
-        value: false,
-        reflectToAttribute: true
-      },
-
-      /**
-       * Specify to order by priority the set of records reflected on the
-       * client.
-       */
-      orderByPriority: {
-        type: Boolean,
-        value: false,
-        reflectToAttribute: true
-      },
-
-      /**
-       * Specify a maximum number of records reflected on the client limited to
-       * the first certain number of children.
-       */
-      limitToFirst: {
-        type: Number,
-        value: null,
-        reflectToAttribute: true,
-      },
-
-      /**
-       * Specify a maximum number of records reflected on the client limited to
-       * the last certain number of children.
-       */
-      limitToLast: {
-        type: Number,
-        value: null,
-        reflectToAttribute: true
-      },
-
-      /**
-       * Specify a start record for the set of records reflected in the
-       * collection.
-       */
-      startAt: {
-        type: String,
-        value: null,
-        reflectToAttribute: true
-      },
-
-      /**
-       * Specify an end record for the set of records reflected in the
-       * collection.
-       */
-      endAt: {
-        type: String,
-        value: null,
-        reflectToAttribute: true
-      },
-
-      /**
-       * Specify to create a query which includes children which match the
-       * specified value. The argument type depends on which orderBy*() function
-       * was used in this query. Specify a value that matches the orderBy*()
-       * type.
-       */
-      equalTo: {
-        type: String,
-        value: null,
-        reflectToAttribute: true
-      },
-
-      _valueMap: {
-        type: Object,
-        value: function() {
-          return {};
+      remove: function(data) {
+        if (data == null || data.__firebaseKey__ == null) {
+          this._error('Failed to remove unknown value:', data);
+          return;
         }
+
+        this._log('Removing collection item "' + data.__firebaseKey__ + '"', data.value);
+
+        this.removeByKey(data.__firebaseKey__);
       },
 
-      _orderByMethodName: {
-        computed: '_computeOrderByMethodName(orderByChild, orderByKey, orderByValue, orderByPriority)'
+      /**
+       * Look up an item in the local `data` Array by key.
+       *
+       * @param {String} key The key associated with the item in the parent
+       * document.
+       */
+      getByKey: function(key) {
+        return this._valueMap[key];
       },
 
-      _orderByTypeCast: {
-        computed: '_computeOrderByTypeCast(orderByChild, orderByKey, orderByValue, orderByPriority)'
+      /**
+       * Remove an item from the document associated with `location` by key.
+       *
+       * @param {String} key The key associated with the item in the document
+       * located at `location`.
+       */
+      removeByKey: function(key) {
+        this.query.ref().child(key).remove();
       },
 
-      _startAt: {
-        computed: '_computeStartAt(startAt, _orderByTypeCast)'
-      },
+      _applyLocalDataChanges: function(change) {
+        var pathParts = change.path.split('.');
+        var firebaseKey;
+        var key;
+        var value;
 
-      _endAt: {
-        computed: '_computeEndAt(endAt, _orderByTypeCast)'
-      },
-
-      _equalTo: {
-        computed: '_computeEqualTo(equalTo, _orderByTypeCast)'
-      }
-    },
-
-    listeners: {
-      'firebase-child-added': '_onFirebaseChildAdded',
-      'firebase-child-removed': '_onFirebaseChildRemoved',
-      'firebase-child-changed': '_onFirebaseChildChanged',
-      'firebase-child-moved': '_onFirebaseChildChanged',
-    },
-
-    /**
-     * Add an item to the document referenced at `location`. A key associated
-     * with the item will be created by Firebase, and can be accessed via the
-     * Firebase Query instance returned by this method.
-     *
-     * @param {Object} data A value to add to the document.
-     * @return {Object} A Firebase Query instance referring to the added item.
-     */
-    add: function(data) {
-      var query;
-
-      this._log('Adding new item to collection with value:', data);
-
-      query = this.query.ref().push();
-      query.set(data);
-
-      return query;
-    },
-
-    /**
-     * Remove an item from the document referenced at `location`. The item
-     * is assumed to be an identical reference to an item already in the
-     * `data` Array.
-     *
-     * @param {Object} data An identical reference to an item in `this.data`.
-     */
-    remove: function(data) {
-      if (data == null || data.__firebaseKey__ == null) {
-        this._error('Failed to remove unknown value:', data);
-        return;
-      }
-
-      this._log('Removing collection item "' + data.__firebaseKey__ + '"', data.value);
-
-      this.removeByKey(data.__firebaseKey__);
-    },
-
-    /**
-     * Look up an item in the local `data` Array by key.
-     *
-     * @param {String} key The key associated with the item in the parent
-     * document.
-     */
-    getByKey: function(key) {
-      return this._valueMap[key];
-    },
-
-    /**
-     * Remove an item from the document associated with `location` by key.
-     *
-     * @param {String} key The key associated with the item in the document
-     * located at `location`.
-     */
-    removeByKey: function(key) {
-      this.query.ref().child(key).remove();
-    },
-
-    _applyLocalDataChanges: function(change) {
-      var pathParts = change.path.split('.');
-      var key;
-      var value;
-
-      if (pathParts.length < 2 || pathParts[1] === 'splices') {
-        return;
-      }
-
-      key = pathParts[1];
-      value = Polymer.Collection.get(change.base).getItem(key);
-      this.query.ref().child(value.__firebaseKey__).set(value);
-    },
-
-    _computeQuery: function(location, limitToFirst, limitToLast, orderByMethodName, startAt, endAt, equalTo) {
-      var query;
-
-      if (!location) {
-        return;
-      }
-
-      query = new Firebase(location);
-
-      if (orderByMethodName) {
-        if (orderByMethodName === 'orderByChild') {
-          query = query[orderByMethodName](this.orderByChild);
-        } else {
-          query = query[orderByMethodName]();
+        if (pathParts.length < 2 || pathParts[1] === 'splices') {
+          return;
         }
-      }
 
-      if (startAt != null) {
-        query = query.startAt(startAt);
-      }
+        key = pathParts[1];
+        value = Polymer.Collection.get(change.base).getItem(key);
 
-      if (endAt != null) {
-        query = query.endAt(endAt);
-      }
+        // Temporarily remove the client-only `__firebaseKey__` property:
+        firebaseKey = value.__firebaseKey__;
+        value.__firebaseKey__ = null;
 
-      if (equalTo != null) {
-        query = query.equalTo(equalTo);
-      }
+        this.query.ref().child(firebaseKey).set(value);
 
-      if (limitToLast != null) {
-        query = query.limitToLast(limitToLast);
-      }
+        value.__firebaseKey__ = firebaseKey;
+      },
 
-      if (limitToFirst != null) {
-        query = query.limitToFirst(limitToFirst);
-      }
+      _computeQuery: function(location, limitToFirst, limitToLast, orderByMethodName, startAt, endAt, equalTo) {
+        var query;
 
-      return query;
-    },
+        if (!location) {
+          return;
+        }
 
-    _queryChanged: function() {
-      Polymer.FirebaseQueryBehavior._queryChanged.apply(this, arguments);
-      this._valueMap = {};
-      this._setData([]);
-    },
+        query = new Firebase(location);
 
-    _computeOrderByMethodName: function(orderByChild, orderByKey, orderByValue, orderByPriority) {
-      if (orderByChild) {
-        return 'orderByChild';
-      }
+        if (orderByMethodName) {
+          if (orderByMethodName === 'orderByChild') {
+            query = query[orderByMethodName](this.orderByChild);
+          } else {
+            query = query[orderByMethodName]();
+          }
+        }
 
-      if (orderByKey) {
-        return 'orderByKey';
-      }
+        if (startAt != null) {
+          query = query.startAt(startAt);
+        }
 
-      if (orderByValue) {
-        return 'orderByValue';
-      }
+        if (endAt != null) {
+          query = query.endAt(endAt);
+        }
 
-      if (orderByPriority) {
-        return 'orderByPriority';
-      }
+        if (equalTo != null) {
+          query = query.equalTo(equalTo);
+        }
 
-      return null;
-    },
+        if (limitToLast != null) {
+          query = query.limitToLast(limitToLast);
+        }
 
-    _computeOrderByTypeCast: function(orderByChild, orderByKey, orderByValue, orderByPriority) {
-      if (orderByKey) {
-        return String;
-      }
+        if (limitToFirst != null) {
+          query = query.limitToFirst(limitToFirst);
+        }
 
-      return function(value) {
-        return value;
-      }
-    },
+        return query;
+      },
 
-    _computeStartAt: function(startAt, orderByTypeCast) {
-      return orderByTypeCast(startAt);
-    },
+      _queryChanged: function() {
+        Polymer.FirebaseQueryBehavior._queryChanged.apply(this, arguments);
+        this._valueMap = {};
+        this._setData([]);
+      },
 
-    _computeEndAt: function(endAt, orderByTypeCast) {
-      return orderByTypeCast(endAt);
-    },
+      _computeOrderByMethodName: function(orderByChild, orderByKey, orderByValue, orderByPriority) {
+        if (orderByChild) {
+          return 'orderByChild';
+        }
 
-    _computeEqualTo: function(equalTo, orderByTypeCast) {
-      return orderByTypeCast(equalTo);
-    },
+        if (orderByKey) {
+          return 'orderByKey';
+        }
 
-    _valueFromSnapshot: function(snapshot) {
-      var value = snapshot.val();
+        if (orderByValue) {
+          return 'orderByValue';
+        }
 
-      if (!(value instanceof Object)) {
-        value = {
-          value: value,
-          __firebasePrimitive__: true
+        if (orderByPriority) {
+          return 'orderByPriority';
+        }
+
+        return null;
+      },
+
+      _computeOrderByTypeCast: function(orderByChild, orderByKey, orderByValue, orderByPriority, orderValueType) {
+        return function typeCast(value) {
+          if (!orderByKey &&
+              value != null &&
+              FirebaseCollection.ORDER_VALUE_TYPES[orderValueType]) {
+            return FirebaseCollection.ORDER_VALUE_TYPES[orderValueType](value);
+          }
+
+          return value;
         };
+      },
+
+      _computeStartAt: function(startAt, orderByTypeCast) {
+        return orderByTypeCast(startAt);
+      },
+
+      _computeEndAt: function(endAt, orderByTypeCast) {
+        return orderByTypeCast(endAt);
+      },
+
+      _computeEqualTo: function(equalTo, orderByTypeCast) {
+        return orderByTypeCast(equalTo);
+      },
+
+      _valueFromSnapshot: function(snapshot) {
+        var value = snapshot.val();
+
+        if (!(value instanceof Object)) {
+          value = {
+            value: value,
+            __firebasePrimitive__: true
+          };
+        }
+
+        value.__firebaseKey__ = snapshot.key();
+
+        return value;
+      },
+
+      _valueToPersistable: function(value) {
+        var persistable;
+
+        if (value.__firebasePrimitive__) {
+          return value.value;
+        }
+
+        persistable = {};
+
+        for (var property in value) {
+          if (property === '__firebaseKey__') {
+            continue;
+          }
+
+          persistable[property] = value[property];
+        }
+
+        return persistable;
+      },
+
+      _onFirebaseChildAdded: function(event) {
+        this._applyRemoteDataChange(function() {
+          var value = this._valueFromSnapshot(event.detail.childSnapshot);
+          var previousValueKey = event.detail.previousChildName;
+          var index = previousValueKey != null ?
+            this.data.indexOf(this._valueMap[previousValueKey]) + 1 : 0;
+
+          this._valueMap[value.__firebaseKey__] = value;
+
+          this.splice('data', index, 0, value);
+        });
+      },
+
+      _onFirebaseChildRemoved: function(event) {
+        this._applyRemoteDataChange(function() {
+          var key = event.detail.oldChildSnapshot.key();
+          var value = this._valueMap[key];
+
+          if (!value) {
+            this._error('Received firebase-child-removed event for unknown child "' + key + '"');
+            return;
+          }
+
+          this._valueMap[key] = null;
+          this.splice('data', this.data.indexOf(value), 1);
+        });
+      },
+
+      _onFirebaseChildChanged: function(event) {
+        this._applyRemoteDataChange(function() {
+          var value = this._valueFromSnapshot(event.detail.childSnapshot);
+          var oldValue = this._valueMap[value.__firebaseKey__];
+
+          if (!oldValue) {
+            this._error('Received firebase-child-changed event for unknown child "' + value.__firebaseKey__ + '"');
+            return;
+          }
+
+          this._valueMap[oldValue.__firebaseKey__] = null;
+          this._valueMap[value.__firebaseKey__] = value;
+          this.splice('data', this.data.indexOf(oldValue), 1, value);
+        });
+      },
+
+      _onFirebaseChildMoved: function(event) {
+        this._applyRemoteDataChange(function() {
+          var key = event.detail.childSnapshot.key();
+          var value = this._valueMap[key];
+          var previousChild;
+          var newIndex;
+
+          if (!value) {
+            this._error('Received firebase-child-moved event for unknown child "' + key + '"');
+            return;
+          }
+
+          previousValue = event.detail.previousChildName != null ?
+            this._valueMap[event.detail.previousChildName] : null;
+          newIndex = previousValue != null ?
+            this.data.indexOf(previousValue) + 1 : 0;
+
+          this.splice('data', this.data.indexOf(value), 1);
+          this.splice('data', newIndex, 0, value);
+        });
       }
+    });
 
-      value.__firebaseKey__ = snapshot.key();
-
-      return value;
-    },
-
-    _valueToPersistable: function(value) {
-      var persistable;
-
-      if (value.__firebasePrimitive__) {
-        return value.value;
-      }
-
-      persistable = {};
-
-      for (var property in value) {
-        if (property === '__firebaseKey__') {
-          continue;
-        }
-
-        persistable[property] = value[property];
-      }
-
-      return persistable;
-    },
-
-    _onFirebaseChildAdded: function(event) {
-      this._applyRemoteDataChange(function() {
-        var value = this._valueFromSnapshot(event.detail.childSnapshot);
-        var previousValueKey = event.detail.previousChildName;
-        var index = previousValueKey != null ?
-          this.data.indexOf(this._valueMap[previousValueKey]) + 1 : 0;
-
-        this._valueMap[value.__firebaseKey__] = value;
-
-        this.splice('data', index, 0, value);
-      });
-    },
-
-    _onFirebaseChildRemoved: function(event) {
-      this._applyRemoteDataChange(function() {
-        var key = event.detail.oldChildSnapshot.key();
-        var value = this._valueMap[key];
-
-        if (!value) {
-          this._error('Received firebase-child-removed event for unknown child "' + key + '"');
-          return;
-        }
-
-        this._valueMap[key] = null;
-        this.splice('data', this.data.indexOf(value), 1);
-      });
-    },
-
-    _onFirebaseChildChanged: function(event) {
-      this._applyRemoteDataChange(function() {
-        var value = this._valueFromSnapshot(event.detail.childSnapshot);
-        var oldValue = this._valueMap[value.__firebaseKey__];
-
-        if (!oldValue) {
-          this._error('Received firebase-child-changed event for unknown child "' + value.__firebaseKey__ + '"');
-          return;
-        }
-
-        this._valueMap[oldValue.__firebaseKey__] = null;
-        this._valueMap[value.__firebaseKey__] = value;
-        this.splice('data', this.data.indexOf(oldValue), 1, value);
-      });
-    },
-
-    _onFirebaseChildMoved: function(event) {
-      this._applyRemoteDataChange(function() {
-        var key = event.detail.childSnapshot.key();
-        var value = this._valueMap[key];
-        var previousChild;
-        var newIndex;
-
-        if (!value) {
-          this._error('Received firebase-child-moved event for unknown child "' + key + '"');
-          return;
-        }
-
-        previousValue = event.detail.previousChildName != null ?
-          this._valueMap[event.detail.previousChildName] : null;
-        newIndex = previousValue != null ?
-          this.data.indexOf(previousValue) + 1 : 0;
-
-        this.splice('data', this.data.indexOf(value), 1);
-        this.splice('data', newIndex, 0, value);
-      });
-    }
-  });
+    FirebaseCollection.ORDER_VALUE_TYPES = {
+      string: String,
+      number: Number,
+      boolean: Boolean
+    };
+  })();
 </script>

--- a/firebase-collection.html
+++ b/firebase-collection.html
@@ -270,15 +270,15 @@ manipulation of the collection without direct knowledge of Firebase key values.
 
     _applyLocalDataChanges: function(change) {
       var pathParts = change.path.split('.');
-      var index;
+      var key;
       var value;
 
       if (pathParts.length < 2 || pathParts[1] === 'splices') {
         return;
       }
 
-      index = parseInt(pathParts[1], 10);
-      value = this.data[index];
+      key = pathParts[1];
+      value = Polymer.Collection.get(change.base).getItem(key);
       this.query.ref().child(value.__firebaseKey__).set(value);
     },
 

--- a/firebase-collection.html
+++ b/firebase-collection.html
@@ -296,7 +296,12 @@ manipulation of the collection without direct knowledge of Firebase key values.
         var key;
         var value;
 
-        if (pathParts.length < 2 || pathParts[1] === 'splices') {
+        if (pathParts.length < 2 || pathParts[1] === 'length') {
+          return;
+        }
+
+        if (pathParts[1] === 'splices') {
+          this._applySplicesToRemoteData(change.value.indexSplices);
           return;
         }
 
@@ -310,6 +315,23 @@ manipulation of the collection without direct knowledge of Firebase key values.
         this.query.ref().child(firebaseKey).set(value);
 
         value.__firebaseKey__ = firebaseKey;
+      },
+
+      _applySplicesToRemoteData: function(splices) {
+        this._log('splices', splices);
+        splices.forEach(function(splice) {
+          var added = splice.object.slice(splice.index, splice.index + splice.addedCount);
+
+          splice.removed.forEach(function(removed) {
+            this.remove(removed);
+          }, this);
+
+          this.data.splice(splice.index, splice.addedCount);
+
+          added.forEach(function(added) {
+            this.add(added);
+          }, this);
+        }, this);
       },
 
       _computeQuery: function(location, limitToFirst, limitToLast, orderByMethodName, startAt, endAt, equalTo) {
@@ -454,14 +476,19 @@ manipulation of the collection without direct knowledge of Firebase key values.
         this._applyRemoteDataChange(function() {
           var key = event.detail.oldChildSnapshot.key();
           var value = this._valueMap[key];
+          var index;
 
           if (!value) {
             this._error('Received firebase-child-removed event for unknown child "' + key + '"');
             return;
           }
 
+          index = this.data.indexOf(value);
           this._valueMap[key] = null;
-          this.splice('data', this.data.indexOf(value), 1);
+
+          if (index !== -1) {
+            this.splice('data', index, 1);
+          }
         });
       },
 

--- a/test/firebase-collection.html
+++ b/test/firebase-collection.html
@@ -65,7 +65,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
-    suite('<firebase-document>', function() {
+    suite('<firebase-collection>', function() {
       var firebase;
 
       suite('basic usage', function() {

--- a/test/firebase-collection.html
+++ b/test/firebase-collection.html
@@ -167,6 +167,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('adds a new child based on local changes');
+
         test('updates the child key in place with the new value', function(done) {
           var childrenKeys = [];
 


### PR DESCRIPTION
 - When specifying a `start-at`, `end-at` or `equal-to` attribute, the
   type of the value can now be coerced by specifying an
   `order-value-type` attribute in cases where the default `String`
   results in incorrect sets.
 - When specifying to `order-by-type`, some attributes with `null`
   values were being accidentally cast to `String`. This has been
   corrected.
 - The implementation-specific `__firebaseKey__` is no longer
   accidentally echoed to the Firebase representation of the data.
 - Local splices will now reflect in remote data.
 - Re-ordered data sets will yield the correct item when accessed by index.

/cc @robdodson