### PR TITLE
user object was not passed as part of the user-created event object

### DIFF
--- a/firebase-auth.html
+++ b/firebase-auth.html
@@ -278,9 +278,9 @@ Element wrapper for the Firebase authentication API (https://www.firebase.com/do
      * @param {string} password
      */
     createUser: function(email, password) {
-        this.ref.createUser({email: email, password: password}, function(error) {
+        this.ref.createUser({email: email, password: password}, function(error, user) {
           if (!error) {
-            this.fire('user-created');
+            this.fire('user-created', {user: user});
           } else {
             this.fire('error', error);
           }


### PR DESCRIPTION
Firebase createUser API returns a user object, in case of success, and stamps the uid inside it. Updated the createUser method to return that user object as part of the event object when user-created event is fired.