### PR TITLE
_authHandler called twice during login

### DIFF
--- a/firebase-auth.html
+++ b/firebase-auth.html
@@ -151,8 +151,6 @@ Element wrapper for the Firebase authentication API (https://www.firebase.com/do
       if (error) {
         // an error occurred while attempting login
         this.fire('error', error);
-      } else {
-        this._authHandler(user);
       }
     },
 


### PR DESCRIPTION
The _authHandler function is being called twice whenever the login function is called (and succeeded). The _loginHandler is the callback function for all of the 'auth functions', when run and without error calls the _authHandler. At the same time, the onAuth firebase function (set on the _locationChanged function) will call the _authHandle whenever the authorization changes the state. For this reason, _authHandler on a valid login is being called twice and thus the 'login' event fired twice.

There is no need for the _loginHandler function (callback of the login function) to be run on succeed as the _authHandler function was already set up on the onAuth firebase function and will be called when the login is performed and the authorization changes of state.