### PR TITLE
Deep reference not set & previous value used

### DIFF
--- a/firebase-document.html
+++ b/firebase-document.html
@@ -73,8 +73,8 @@ document.
       }
 
       this._setRemoteDocumentChild(
-        pathFragments[1],
-        change.base[pathFragments[1]]
+        pathFragments.slice(1).join('/'),
+        change.value
       );
     },
 


### PR DESCRIPTION
Setting a value via `this.set('parent.value')` would fail to set.
In addition the value didn't seem to be set, debugging in step though the old value was being used instead of the new value.
