### PR TITLE
Documentation for logout function incorrectly referred to login.

### DIFF
--- a/firebase-auth.html
+++ b/firebase-auth.html
@@ -236,9 +236,9 @@ Element wrapper for the Firebase authentication API (https://www.firebase.com/do
     /**
      * Performs a logout attempt.
      *
-     * If the login is successful, the `logout` event is fired.
+     * If the logout is successful, the `logout` event is fired.
      *
-     * If login fails, the `error` event is fired, with `e.detail` containing error
+     * If logout fails, the `error` event is fired, with `e.detail` containing error
      * information supplied from Firebase.
      *
      * If the browswer supports `navigator.onLine` network status reporting and the


### PR DESCRIPTION
Looks like a copy/paste error!