### PR TITLE
Use "set" instead of "splice" for child changed

### DIFF
--- a/firebase-collection.html
+++ b/firebase-collection.html
@@ -586,7 +586,7 @@ manipulation of the collection without direct knowledge of Firebase key values.
 
           this._valueMap[oldValue.__firebaseKey__] = null;
           this._valueMap[value.__firebaseKey__] = value;
-          this.splice('data', this.data.indexOf(oldValue), 1, value);
+          this.set('data.' + this.data.indexOf(oldValue), value);
         });
       },
 


### PR DESCRIPTION
When using firebase-collection in a dom-repeat, the whole dom-repeat has to refresh every time a child changes, instead of only the modified child. That's because it is updating the array with a splice.

If we use a "set" instead, only the actual child is refreshed. 

The main problem with the "splice" was that I was losing focus on an input during the refresh.