### PR TITLE
Add authenticated event

### DIFF
--- a/firebase-auth.html
+++ b/firebase-auth.html
@@ -179,6 +179,8 @@ Element wrapper for the Firebase authentication API (https://www.firebase.com/do
 
         this._setStatusKnown(true);
       }
+      // Fire an `authenticated` event to signal a change in auth status
+      this.fire('authenticated');
     },
 
     /**


### PR DESCRIPTION
The `firebase-auth` element provides events for `on-login`, `on-error`, and `on-logout`, however there is no event fired when Firebase confirms the lack of a logged in user. This pull request adds such an event (tentatively called `authenticated`), which is fired any time the `ref`'s authentication state changes (due to the callback provided to `ref.onAuth`). This can also be thought of as being called whenever `statusKnown` is set to true.

To use the `authenticated` event, simply add an `on-authenticated` argument to the `firebase-auth` element with a value representing the name of the method to call. Note that this method will be called every time the authentication state changes (including logins, logouts, and page reloads).
