### PR TITLE
Added 'firebase-loaded' event to notify clients when initial data has…

### DIFF
--- a/firebase-query-behavior.html
+++ b/firebase-query-behavior.html
@@ -69,6 +69,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.location = '';
     },
 
+    listeners: {
+      'firebase-value': '_onFirebaseLoaded'
+    },
+
+    _onFirebaseLoaded: function() {
+      this.unlisten(this, 'firebase-value', '_onFirebaseLoaded');
+      this.fire('firebase-loaded');
+    },
+
     _localDataChanged: function(changes) {
       // Virtual..
     },
@@ -87,7 +96,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _dataChanged: function(changes) {
       if (this._receivingRemoteChanges ||
-          this._receivingLocalChanges) {
+              this._receivingLocalChanges) {
         return;
       }
 
@@ -102,6 +111,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (query) {
         this._listenToQuery(query);
       }
+      this.listen(this, 'firebase-value', '_onFirebaseLoaded');
     },
 
     _listenToQuery: function(query) {
@@ -111,7 +121,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       query.on('child_removed', this._onQueryChildRemoved, this._onQueryCancel, this);
       query.on('child_changed', this._onQueryChildChanged, this._onQueryCancel, this);
       query.on('child_moved', this._onQueryChildMoved, this._onQueryCancel, this);
-      query.once('value', this._onInitialDataLoaded, this);
     },
 
     _stopListeningToQuery: function(query) {
@@ -157,10 +166,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         childSnapshot: childSnapshot,
         previousChildName: previousChildName
       }, { bubbles: false });
-    },
-
-    _onInitialDataLoaded: function(snapshot) {
-      this.fire('firebase-loaded', snapshot, { bubbles: false });
     },
 
     _onQueryCancel: function(error) {

--- a/firebase-query-behavior.html
+++ b/firebase-query-behavior.html
@@ -111,6 +111,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       query.on('child_removed', this._onQueryChildRemoved, this._onQueryCancel, this);
       query.on('child_changed', this._onQueryChildChanged, this._onQueryCancel, this);
       query.on('child_moved', this._onQueryChildMoved, this._onQueryCancel, this);
+      query.once('value', this._onInitialDataLoaded, this);
     },
 
     _stopListeningToQuery: function(query) {
@@ -156,6 +157,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         childSnapshot: childSnapshot,
         previousChildName: previousChildName
       }, { bubbles: false });
+    },
+
+    _onInitialDataLoaded: function(snapshot) {
+      this.fire('firebase-loaded', snapshot, { bubbles: false });
     },
 
     _onQueryCancel: function(error) {

--- a/test/firebase-document.html
+++ b/test/firebase-document.html
@@ -80,7 +80,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('document updating', function() {
         setup(function(done) {
           firebase = fixture('UpdateableDocument');
-          waitForEvent(firebase, 'firebase-value').then(function() {
+          waitForEvent(firebase, 'firebase-loaded').then(function() {
             done();
           });
         });


### PR DESCRIPTION
… been loaded and can be accessed.

Hi,

There are instances when a client needs to know when it is able to start accessing data from firebase. Having an event to signal that really helps.

Following [the docs from firebase](https://www.firebase.com/docs/web/guide/retrieving-data.html), this PR creates an event to signal the client when data from Firebase has been loaded and can be accessed. 
