### PR TITLE
Fire error event when query failed

### DIFF
--- a/firebase-query-behavior.html
+++ b/firebase-query-behavior.html
@@ -160,6 +160,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _onQueryCancel: function(error) {
       if (error) {
+        this.fire('firebase-error', error);
         this._error('Firebase Error', error);
       }
 


### PR DESCRIPTION
This is a fix for #130.

Applications need a way to handle errors that are thrown by the firebase library like `Permission denied`.
