### PR TITLE
Fix firebase element documentation not listing FirebaseQueryBehaviour

### DIFF
--- a/firebase-query-behavior.html
+++ b/firebase-query-behavior.html
@@ -12,11 +12,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="firebase.html">
 
 <script>
-  /** @polymerBehavior
-  **Note: This element is for the older Firebase 2 API**
-  For the latest official Firebase 3.0-compatible component from the Firebase team,
-  see the [polymerfire](https://github.com/firebase/polymerfire) component.
-  */
+  /**
+   * **Note: This element is for the older Firebase 2 API**
+   * For the latest official Firebase 3.0-compatible component from the Firebase team,
+   * see the [polymerfire](https://github.com/firebase/polymerfire) component.
+   *
+   * @polymerBehavior
+   */
   Polymer.FirebaseQueryBehavior = {
     properties: {
       /**


### PR DESCRIPTION
Hydrolysis doesn't like the formatting of the doc for FirebaseQueryBehaviour, which makes the output a little bit broken...

See the behaviours list of https://elements.polymer-project.org/elements/firebase-element.

Rearranging fixes the problem (and is also arguably more readable).